### PR TITLE
pcp-254 fixed bug when there wasn't any output for W4 it would spin t…

### DIFF
--- a/pcp_alpha/Frontend/static/js_custom/pcp_custom_jquery.js
+++ b/pcp_alpha/Frontend/static/js_custom/pcp_custom_jquery.js
@@ -549,7 +549,9 @@ function execute_sequence_output(specific_id, updateid, counter=0, backoff=2000)
 
         if(counter == 10){
 //            console.log("About to BREAK");
+            // W4 errors out or the job doesn't work for whatever reason.
             $("#updateid"+updateid).empty();
+            $("#updateid"+updateid).attr({"class": ""});
             $("#updateid"+updateid).append("No data to return at the moment :(");
             $("#updateid"+updateid).parent().css("background-color", "white");
         } else {


### PR DESCRIPTION
…he error message

- fixed bug that would spin the error message when W4 didn't have any output
- this fix was in pcp_custom_jquery.js file